### PR TITLE
Update to AsyncKeyedLock 6.2.1

### DIFF
--- a/CAVX.Bots.Framework/CAVX.Bots.Framework.csproj
+++ b/CAVX.Bots.Framework/CAVX.Bots.Framework.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.1.1" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.2.0" />
     <PackageReference Include="CliWrap" Version="3.6.0" />
     <PackageReference Include="Discord.Net" Version="3.9.0" />
     <PackageReference Include="ScottPlot" Version="4.1.60" />

--- a/CAVX.Bots.Framework/CAVX.Bots.Framework.csproj
+++ b/CAVX.Bots.Framework/CAVX.Bots.Framework.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="6.2.0" />
+    <PackageReference Include="AsyncKeyedLock" Version="6.2.1" />
     <PackageReference Include="CliWrap" Version="3.6.0" />
     <PackageReference Include="Discord.Net" Version="3.9.0" />
     <PackageReference Include="ScottPlot" Version="4.1.60" />


### PR DESCRIPTION
This version now provides an alternate technique called striped locking. With this PR, nothing changes in the way things are done, but if you would like to check out the advantages and disadvantages of the new mechanism, please read up on it at https://github.com/MarkCiliaVincenti/AsyncKeyedLock/wiki